### PR TITLE
Fix specific volumes below 100 in setWindowVol

### DIFF
--- a/Lib/setWindowVol.ahk
+++ b/Lib/setWindowVol.ahk
@@ -41,6 +41,6 @@ setWindowVol(winName:="a",vol:="n"){
 		else if (vsign="-")
 			vol:=cvol-vol<0?0:cvol-vol
 	} else
-		vol/=100
+		vol/=100.0
 	VA_ISimpleAudioVolume_SetMasterVolume(volume,vol),objRelease(volume)
 }


### PR DESCRIPTION
When `setWindowVol` is given a relative volume, such as `"+10"`, it divides it by 100 like this:
```AutoHotkey
vol:=subStr(vol,2),vol/=100
```
This gives a float, as expected. However, a specific volume, such as `"50"`, is divided like this:
```AutoHotkey
vol/=100
```
Unfortunately, backwards-compatible behavior causes this line to floor the result to 0:

> When /= is the leftmost operator in an expression and it is not part of a multi-statement expression, it performs floor division unless one of the inputs is floating point (in all other cases, /= performs true division)

Changing the `100` to a float avoids this behavior.